### PR TITLE
Texture preview options

### DIFF
--- a/include/ui/preview/PreviewTexture.h
+++ b/include/ui/preview/PreviewTexture.h
@@ -16,7 +16,6 @@ class PreviewTexture : public Preview, public QObject
 
     TextureRenderWidget* m_textureWidget;
     QCheckBox* m_showAlphaCheckbox;
-    QSlider* m_exposureSlider;
     bool m_hasAlpha;
 
 public:

--- a/include/ui/preview/PreviewTexture.h
+++ b/include/ui/preview/PreviewTexture.h
@@ -5,9 +5,10 @@
 #include "ui/preview/TextureRenderWidget.h"
 
 #include <QtWidgets/QCheckBox>
+#include <QtWidgets/QSlider>
 #include <QtCore/QObject>
 
-class PreviewTexture : public Preview
+class PreviewTexture : public Preview, public QObject
 {
     PreviewTexture() = default;
     PreviewTexture(const PreviewTexture&) = delete;
@@ -15,6 +16,8 @@ class PreviewTexture : public Preview
 
     TextureRenderWidget* m_textureWidget;
     QCheckBox* m_showAlphaCheckbox;
+    QSlider* m_exposureSlider;
+    bool m_hasAlpha;
 
 public:
     static PreviewTexture* getInstance(); 
@@ -23,5 +26,5 @@ public:
     void unloadData() override;
     void hide() override;
     void show() override;
-    void setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesReader& pkgs) override;
+    void setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesReader& pkgs) override;    
 };

--- a/include/ui/preview/TextureRenderWidget.h
+++ b/include/ui/preview/TextureRenderWidget.h
@@ -21,21 +21,20 @@ class TextureRenderWidget : public QtOpenGLViewer
     int m_texWidth;
     int m_texHeight;
     bool m_showAlpha;
-    bool m_isHDR;
     float m_gamma;
+    bool m_isHDR;
 
     std::map<WarframeExporter::Texture::TextureCompression, std::tuple<int, int, int>> m_textureMapUncompressed;
     std::map<WarframeExporter::Texture::TextureCompression, int> m_textureMapCompressed;
 
 public:
-    bool m_hasAlpha;
     TextureRenderWidget(QWidget *parent = NULL);
 
     void initializeGL() override;
     void drawScene() override;
     void resizeGL(int width, int height) override;
 
-    bool setTexture(WarframeExporter::Texture::TextureInternal& texture);
+    void setTexture(WarframeExporter::Texture::TextureInternal& texture);
 private:
     void loadTexture();
     void loadSquare();

--- a/include/ui/preview/TextureRenderWidget.h
+++ b/include/ui/preview/TextureRenderWidget.h
@@ -21,19 +21,22 @@ class TextureRenderWidget : public QtOpenGLViewer
     int m_texWidth;
     int m_texHeight;
     bool m_showAlpha;
+    bool m_isHDR;
+    float m_exposure;
+    float m_gamma;
 
     std::map<WarframeExporter::Texture::TextureCompression, std::tuple<int, int, int>> m_textureMapUncompressed;
     std::map<WarframeExporter::Texture::TextureCompression, int> m_textureMapCompressed;
 
 public:
+    bool m_hasAlpha;
     TextureRenderWidget(QWidget *parent = NULL);
 
     void initializeGL() override;
     void drawScene() override;
     void resizeGL(int width, int height) override;
 
-    void setTexture(WarframeExporter::Texture::TextureInternal& texture);
-
+    bool setTexture(WarframeExporter::Texture::TextureInternal& texture);
 private:
     void loadTexture();
     void loadSquare();
@@ -43,4 +46,5 @@ private:
 
 public slots:
     void showAlpha(int state);
+    void changeExposure(int exposure);
 };

--- a/include/ui/preview/TextureRenderWidget.h
+++ b/include/ui/preview/TextureRenderWidget.h
@@ -22,7 +22,6 @@ class TextureRenderWidget : public QtOpenGLViewer
     int m_texHeight;
     bool m_showAlpha;
     bool m_isHDR;
-    float m_exposure;
     float m_gamma;
 
     std::map<WarframeExporter::Texture::TextureCompression, std::tuple<int, int, int>> m_textureMapUncompressed;
@@ -46,5 +45,4 @@ private:
 
 public slots:
     void showAlpha(int state);
-    void changeExposure(int exposure);
 };

--- a/src/ui/preview/PreviewTexture.cpp
+++ b/src/ui/preview/PreviewTexture.cpp
@@ -49,6 +49,6 @@ PreviewTexture::setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesRe
     WarframeExporter::Texture::TextureInternal textureData = textureExtractor->getTexture(fileEntry, pkgs);
     m_textureWidget->setTexture(textureData);
 
-    bool hasAlpha = ddspp::hasAlpha(textureData.header.ddsFormat);
+    bool hasAlpha = textureData.header.ddsFormat == ddspp::DXGIFormat::BC1_UNORM ? false : ddspp::hasAlpha(textureData.header.ddsFormat);
     m_showAlphaCheckbox->setHidden(!hasAlpha);
 }

--- a/src/ui/preview/PreviewTexture.cpp
+++ b/src/ui/preview/PreviewTexture.cpp
@@ -14,19 +14,12 @@ PreviewTexture::setupUi(QWidget* parentWidget, QVBoxLayout* parentLayout, QWidge
     parentLayout->addWidget(m_textureWidget);
     m_textureWidget->hide();
 
-    m_exposureSlider = new QSlider(Qt::Horizontal, previewButtonsArea);
-    m_exposureSlider->setValue(10);
-    m_exposureSlider->setRange(1, 100);
-    layout->addWidget(m_exposureSlider);
-    m_exposureSlider->hide();
-
     m_showAlphaCheckbox = new QCheckBox(previewButtonsArea);
     layout->addWidget(m_showAlphaCheckbox);
     m_showAlphaCheckbox->setText("Apply Alpha");
     m_showAlphaCheckbox->hide();
 
     QObject::connect(m_showAlphaCheckbox, &QCheckBox::stateChanged, m_textureWidget, &TextureRenderWidget::showAlpha);
-    QObject::connect(m_exposureSlider, &QSlider::valueChanged, m_textureWidget, &TextureRenderWidget::changeExposure);
 }
 
 void
@@ -39,7 +32,6 @@ PreviewTexture::hide()
 {
     m_textureWidget->hide();
     m_showAlphaCheckbox->hide();
-    m_exposureSlider->hide();
 }
 
 void
@@ -47,7 +39,6 @@ PreviewTexture::show()
 {
     m_textureWidget->show();
     m_showAlphaCheckbox->show();
-    m_exposureSlider->show();
 }
 
 void
@@ -56,8 +47,6 @@ PreviewTexture::setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesRe
     auto textureExtractor = WarframeExporter::Texture::TextureExtractor::getInstance();
 
     WarframeExporter::Texture::TextureInternal textureData = textureExtractor->getTexture(fileEntry, pkgs);
-    m_exposureSlider->setValue(10);
-    m_textureWidget->changeExposure(10);
     bool hasAlpha = m_textureWidget->setTexture(textureData);
     m_showAlphaCheckbox->setHidden(!hasAlpha);
 }

--- a/src/ui/preview/PreviewTexture.cpp
+++ b/src/ui/preview/PreviewTexture.cpp
@@ -47,6 +47,8 @@ PreviewTexture::setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesRe
     auto textureExtractor = WarframeExporter::Texture::TextureExtractor::getInstance();
 
     WarframeExporter::Texture::TextureInternal textureData = textureExtractor->getTexture(fileEntry, pkgs);
-    bool hasAlpha = m_textureWidget->setTexture(textureData);
+    m_textureWidget->setTexture(textureData);
+
+    bool hasAlpha = ddspp::hasAlpha(textureData.header.ddsFormat);
     m_showAlphaCheckbox->setHidden(!hasAlpha);
 }

--- a/src/ui/preview/PreviewTexture.cpp
+++ b/src/ui/preview/PreviewTexture.cpp
@@ -14,12 +14,19 @@ PreviewTexture::setupUi(QWidget* parentWidget, QVBoxLayout* parentLayout, QWidge
     parentLayout->addWidget(m_textureWidget);
     m_textureWidget->hide();
 
+    m_exposureSlider = new QSlider(Qt::Horizontal, previewButtonsArea);
+    m_exposureSlider->setValue(10);
+    m_exposureSlider->setRange(1, 100);
+    layout->addWidget(m_exposureSlider);
+    m_exposureSlider->hide();
+
     m_showAlphaCheckbox = new QCheckBox(previewButtonsArea);
     layout->addWidget(m_showAlphaCheckbox);
     m_showAlphaCheckbox->setText("Apply Alpha");
     m_showAlphaCheckbox->hide();
 
     QObject::connect(m_showAlphaCheckbox, &QCheckBox::stateChanged, m_textureWidget, &TextureRenderWidget::showAlpha);
+    QObject::connect(m_exposureSlider, &QSlider::valueChanged, m_textureWidget, &TextureRenderWidget::changeExposure);
 }
 
 void
@@ -32,6 +39,7 @@ PreviewTexture::hide()
 {
     m_textureWidget->hide();
     m_showAlphaCheckbox->hide();
+    m_exposureSlider->hide();
 }
 
 void
@@ -39,6 +47,7 @@ PreviewTexture::show()
 {
     m_textureWidget->show();
     m_showAlphaCheckbox->show();
+    m_exposureSlider->show();
 }
 
 void
@@ -47,5 +56,8 @@ PreviewTexture::setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesRe
     auto textureExtractor = WarframeExporter::Texture::TextureExtractor::getInstance();
 
     WarframeExporter::Texture::TextureInternal textureData = textureExtractor->getTexture(fileEntry, pkgs);
-    m_textureWidget->setTexture(textureData);
+    m_exposureSlider->setValue(10);
+    m_textureWidget->changeExposure(10);
+    bool hasAlpha = m_textureWidget->setTexture(textureData);
+    m_showAlphaCheckbox->setHidden(!hasAlpha);
 }

--- a/src/ui/preview/TextureRenderWidget.cpp
+++ b/src/ui/preview/TextureRenderWidget.cpp
@@ -1,7 +1,7 @@
 #include "ui/preview/TextureRenderWidget.h"
 
 TextureRenderWidget::TextureRenderWidget(QWidget *parent)
-    : QtOpenGLViewer(parent), m_showAlpha(false), m_hasAlpha(false), m_exposure(1.0f), m_gamma(2.2f), m_isHDR(false)
+    : QtOpenGLViewer(parent), m_showAlpha(false), m_hasAlpha(false), m_gamma(2.2f), m_isHDR(false)
 {
     setIs3D(false);
 
@@ -36,9 +36,6 @@ void
 TextureRenderWidget::drawScene()
 {
     glUseProgram(m_shaderProgram);
-    GLint exposureLoc = glGetUniformLocation(m_shaderProgram, "exposure");
-    glUniform1f(exposureLoc, m_exposure);
-
     GLint isHdrLoc = glGetUniformLocation(m_shaderProgram, "isHDR");
     glUniform1i(isHdrLoc, m_isHDR);
 
@@ -181,7 +178,6 @@ TextureRenderWidget::loadShaders()
         out vec4 FragColor;
         in vec2 TexCoord;
         uniform sampler2D ourTexture;
-        uniform float exposure;
         uniform bool isHDR;
         uniform float gamma;
 
@@ -189,7 +185,6 @@ TextureRenderWidget::loadShaders()
             vec4 texColor = texture(ourTexture, TexCoord);
             vec3 color = texColor.rgb;
 
-            color *= exposure;
             if (isHDR) {
                 color = vec3(1.0) - exp(-color);
                 color = pow(color, vec3(1.0 / gamma));
@@ -263,12 +258,5 @@ TextureRenderWidget::showAlpha(int state)
     else if (state == Qt::CheckState::Unchecked)
         m_showAlpha = false;
 
-    update();
-}
-
-void
-TextureRenderWidget::changeExposure(int exposure)
-{
-    m_exposure = exposure / 10.0f;
     update();
 }


### PR DESCRIPTION
https://github.com/Puxtril/Warframe-Exporter/issues/36
Added condition on alpha checkbox
Icon with Alpha | Texture with no Alpha
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/2143e7fa-5d58-4192-96b4-681ff47049d2) | ![image](https://github.com/user-attachments/assets/88eb6ef9-c93f-4e9b-84f9-4461b4ec35d6)

Added tone mapping for hdr images
No tone mapping | With tone mapping
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/952519e6-ad63-45fc-a987-dd02344740ea) | ![image](https://github.com/user-attachments/assets/ecfc0130-c3f3-4662-a3b8-ff2dee307245)

Fixed a bug with alpha checkbox not working after enabling and then disabling
Opened texture preview| Set alpha checkbox | Disabled alpha checkbox, preview stayed the same
:-------------------------:|:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/425c2441-5b8b-493d-b2a9-a4afa383f01c) | ![image](https://github.com/user-attachments/assets/53ac5733-1e04-4127-8a51-dbed2cfac2f2) |![image](https://github.com/user-attachments/assets/89980cf2-32bf-4306-ac6c-87c7ed4ae09e)

Changed how low resolution images are previewed by making them not scaled to preview size
Old | New
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/2924e04d-faf4-41f5-b20d-9561bdb084c1) | ![image](https://github.com/user-attachments/assets/8d70be27-662e-4898-801a-2ccb57dc6ac2)
