### PR TITLE
Shortcuts + Regex Search

### DIFF
--- a/include/ui/UIExporter.h
+++ b/include/ui/UIExporter.h
@@ -9,6 +9,7 @@
 #include <QTimer>
 #include <QHash>
 #include <QSet>
+#include <QRegularExpression>
 
 #include "LotusLib.h"
 #include "Extractor.h"

--- a/include/ui/UIExporter.h
+++ b/include/ui/UIExporter.h
@@ -10,6 +10,7 @@
 #include <QHash>
 #include <QSet>
 #include <QRegularExpression>
+#include <QShortcut>
 
 #include "LotusLib.h"
 #include "Extractor.h"

--- a/include/ui/UIExporter.h
+++ b/include/ui/UIExporter.h
@@ -56,6 +56,7 @@ public:
     void setup(UiMainWindow* MainWindow);
 
 private:
+    void setupShortcuts(UiMainWindow* MainWindow);
     void saveGeometry();
     void loadGeometry();
 

--- a/include/ui/UIMainWindow.h
+++ b/include/ui/UIMainWindow.h
@@ -3,6 +3,7 @@
 #include "Settings.h"
 
 #include <QtWidgets/qmainwindow.h>
+#include <QShortcut>
 
 class UiMainWindow : public QMainWindow
 {

--- a/include/ui/UIPicker.h
+++ b/include/ui/UIPicker.h
@@ -16,6 +16,7 @@
 #include <QtWidgets/QMessageBox>
 #include <QtCore/qtmetamacros.h>
 #include <QtWidgets/qfiledialog.h>
+#include <QShortcut>
 
 class UiPicker : public QObject, private Ui_WindowPicker
 {

--- a/include/ui/preview/AudioPlaybackWidget.h
+++ b/include/ui/preview/AudioPlaybackWidget.h
@@ -49,4 +49,5 @@ public:
     // `value` is 0-100
     void timelinePositionDragged(int value);
     void setVolume(int value);
+    bool isPlaying();
 };

--- a/include/ui/preview/PreviewAudio.h
+++ b/include/ui/preview/PreviewAudio.h
@@ -40,6 +40,9 @@ public:
     void show() override;
     void setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesReader& pkgs) override;
 
+    void playPause();
+    bool isVisible();
+
 private:
     void createUi(QWidget* parentWidget);
 };

--- a/include/ui/preview/PreviewManager.h
+++ b/include/ui/preview/PreviewManager.h
@@ -27,6 +27,7 @@ public:
 
     void swapToFilePreview(LotusLib::FileEntry& fileEntry);
     void clearPreview();
+    void playPauseAudio();
 
 private:
     Preview* getPreview(LotusLib::FileEntry& fileEntry);

--- a/src/ui/UIExporter.cpp
+++ b/src/ui/UIExporter.cpp
@@ -138,6 +138,12 @@ UiExporter::itemChanged()
 {
     QTreeWidgetItem* item = this->treeWidget->currentItem();
 
+    if (item == nullptr)
+    {
+        this->clearPreview();
+        return;
+    }
+
     int itemType = item->type();
     
     if (itemType == TreeItemDirectory::QTreeWidgetItemType)

--- a/src/ui/UIExporter.cpp
+++ b/src/ui/UIExporter.cpp
@@ -299,7 +299,7 @@ UiExporter::onSearchTextChanged(const QString& text)
 void 
 UiExporter::filterTree() 
 {
-    const QString searchText = searchLineEdit->text().trimmed().toLower();
+    const QString searchText = searchLineEdit->text().trimmed();
     const bool isSearching = !searchText.isEmpty();
 
     if (!isSearching) {
@@ -309,12 +309,24 @@ UiExporter::filterTree()
         return;
     }
 
+    QRegularExpression regex(searchText, QRegularExpression::CaseInsensitiveOption);
+    bool useRegex = regex.isValid();
+
     for (const auto& pair : m_searchIndex) {
         const QString& itemText = pair.first;
         QTreeWidgetItem* item = pair.second;
         item->setHidden(true);
         item->setExpanded(false);
-        if (itemText.contains(searchText)) {
+
+        bool matches = false;
+        if (useRegex) {
+            QRegularExpressionMatch match = regex.match(itemText);
+            matches = match.hasMatch();
+        } else {
+            matches = itemText.contains(searchText.toLower());
+        }
+
+        if (matches) {
             item->setHidden(false);
             QTreeWidgetItem* parent = item->parent();
             while (parent) {

--- a/src/ui/UIExporter.cpp
+++ b/src/ui/UIExporter.cpp
@@ -1,4 +1,5 @@
 #include "ui/UIExporter.h"
+#include <QShortcut>
 
 UiExporter::~UiExporter()
 {
@@ -46,6 +47,8 @@ UiExporter::setup(UiMainWindow *MainWindow)
     m_previewManager.setupUis(this->Preview, this->verticalLayout_3, this->PreviewButtonsArea, this->horizontalLayout_5);
     m_metadataPreview.setupUis(this->MetadataCommonHeader, this->MetadataCompressedValue, this->MetadataDecompressedValue, this->MetadataModifiedValue);
     m_formatPreview.setupUis(this->Format, this->verticalLayout_6);
+
+    setupShortcuts(MainWindow);
 }
 
 void
@@ -321,4 +324,70 @@ UiExporter::filterTree()
             }
         }
     }
+}
+
+void
+UiExporter::setupShortcuts(UiMainWindow* MainWindow)
+{
+    // Search shortcuts (Ctrl+F and /)
+    QShortcut* searchShortcut1 = new QShortcut(QKeySequence("Ctrl+F"), MainWindow);
+    QObject::connect(searchShortcut1, &QShortcut::activated, this->searchLineEdit, [this]() {
+        this->searchLineEdit->setFocus();
+        this->searchLineEdit->selectAll();
+    });
+
+    QShortcut* searchShortcut2 = new QShortcut(QKeySequence("/"), MainWindow);
+    QObject::connect(searchShortcut2, &QShortcut::activated, this->searchLineEdit, [this]() {
+        this->searchLineEdit->setFocus();
+        this->searchLineEdit->selectAll();
+    });
+
+    // Focus shortcuts
+    QShortcut* focusTreeShortcut = new QShortcut(QKeySequence("Ctrl+1"), MainWindow);
+    QObject::connect(focusTreeShortcut, &QShortcut::activated, this->treeWidget, [this]() {
+        this->treeWidget->setFocus();
+    });
+
+    QShortcut* focusPreviewShortcut = new QShortcut(QKeySequence("Ctrl+2"), MainWindow);
+    QObject::connect(focusPreviewShortcut, &QShortcut::activated, this->tabWidget, [this]() {
+        this->tabWidget->setCurrentWidget(this->Preview);
+    });
+
+    QShortcut* focusMetadataShortcut = new QShortcut(QKeySequence("Ctrl+3"), MainWindow);
+    QObject::connect(focusMetadataShortcut, &QShortcut::activated, this->tabWidget, [this]() {
+        this->tabWidget->setCurrentWidget(this->Metadata);
+    });
+
+    QShortcut* focusFormatShortcut = new QShortcut(QKeySequence("Ctrl+4"), MainWindow);
+    QObject::connect(focusFormatShortcut, &QShortcut::activated, this->tabWidget, [this]() {
+        this->tabWidget->setCurrentWidget(this->Format);
+    });
+
+    // Extract shortcuts (Space and Enter)
+    QShortcut* extractShortcut1 = new QShortcut(QKeySequence("Space"), MainWindow);
+    QObject::connect(extractShortcut1, &QShortcut::activated, this->ExtractButton, &QPushButton::click);
+
+    QShortcut* extractShortcut2 = new QShortcut(QKeySequence("Return"), MainWindow);
+    QObject::connect(extractShortcut2, &QShortcut::activated, this->ExtractButton, &QPushButton::click);
+
+    // Audio preview play/pause (Shift+Space)
+    QShortcut* audioShortcut = new QShortcut(QKeySequence("Shift+Space"), MainWindow);
+    QObject::connect(audioShortcut, &QShortcut::activated, this, [this]() {
+        m_previewManager.playPauseAudio();
+    });
+
+    // Cycle through tabs (Alt+Left/Right)
+    QShortcut* cycleLeftShortcut = new QShortcut(QKeySequence("Alt+Left"), MainWindow);
+    QObject::connect(cycleLeftShortcut, &QShortcut::activated, this->tabWidget, [this]() {
+        int currentIndex = this->tabWidget->currentIndex();
+        int newIndex = (currentIndex - 1 + this->tabWidget->count()) % this->tabWidget->count();
+        this->tabWidget->setCurrentIndex(newIndex);
+    });
+
+    QShortcut* cycleRightShortcut = new QShortcut(QKeySequence("Alt+Right"), MainWindow);
+    QObject::connect(cycleRightShortcut, &QShortcut::activated, this->tabWidget, [this]() {
+        int currentIndex = this->tabWidget->currentIndex();
+        int newIndex = (currentIndex + 1) % this->tabWidget->count();
+        this->tabWidget->setCurrentIndex(newIndex);
+    });
 }

--- a/src/ui/UIExporter.cpp
+++ b/src/ui/UIExporter.cpp
@@ -1,5 +1,4 @@
 #include "ui/UIExporter.h"
-#include <QShortcut>
 
 UiExporter::~UiExporter()
 {

--- a/src/ui/UIMainWindow.cpp
+++ b/src/ui/UIMainWindow.cpp
@@ -1,8 +1,13 @@
 #include "ui/UIMainWindow.h"
+#include <QShortcut>
+#include <QApplication>
 
 UiMainWindow::UiMainWindow()
     : QMainWindow()
 {
+    QShortcut* quitShortcut = new QShortcut(QKeySequence("Ctrl+Q"), this);
+    connect(quitShortcut, &QShortcut::activated, this, &QWidget::close);
+
     loadGeometry();
 }
 

--- a/src/ui/UIMainWindow.cpp
+++ b/src/ui/UIMainWindow.cpp
@@ -1,6 +1,4 @@
 #include "ui/UIMainWindow.h"
-#include <QShortcut>
-#include <QApplication>
 
 UiMainWindow::UiMainWindow()
     : QMainWindow()

--- a/src/ui/UIPicker.cpp
+++ b/src/ui/UIPicker.cpp
@@ -1,5 +1,4 @@
 #include "ui/UIPicker.h"
-#include <QShortcut>
 
 UiPicker::UiPicker(QObject *parent)
     : QObject(parent)

--- a/src/ui/UIPicker.cpp
+++ b/src/ui/UIPicker.cpp
@@ -1,4 +1,5 @@
 #include "ui/UIPicker.h"
+#include <QShortcut>
 
 UiPicker::UiPicker(QObject *parent)
     : QObject(parent)
@@ -17,6 +18,15 @@ UiPicker::setupUi(QDialog *WindowPicker)
 
     // When `CacheWindowsInput` is updated, this will show
     this->GameInfoButton->hide();
+
+    QShortcut* quitShortcut = new QShortcut(QKeySequence("Ctrl+Q"), WindowPicker);
+    QObject::connect(quitShortcut, &QShortcut::activated, WindowPicker, &QWidget::close);
+
+    QShortcut* settingsShortcut = new QShortcut(QKeySequence("Ctrl+."), WindowPicker);
+    QObject::connect(settingsShortcut, &QShortcut::activated, &m_additionalSettingsDialog, &QDialog::show);
+
+    QShortcut* loadShortcut = new QShortcut(QKeySequence("Return"), WindowPicker);
+    QObject::connect(loadShortcut, &QShortcut::activated, this->LoadButton, &QPushButton::click);
 }
 
 void

--- a/src/ui/preview/AudioPlaybackWidget.cpp
+++ b/src/ui/preview/AudioPlaybackWidget.cpp
@@ -135,3 +135,9 @@ AudioPlaybackWidget::setVolume(int value)
 {
     m_audioOutput.setVolume(std::pow((value / 100.0), 3));
 }
+
+bool
+AudioPlaybackWidget::isPlaying()
+{
+    return m_mediaPlayer.isPlaying();
+}

--- a/src/ui/preview/PreviewAudio.cpp
+++ b/src/ui/preview/PreviewAudio.cpp
@@ -58,6 +58,25 @@ PreviewAudio::setupWidget(LotusLib::FileEntry& fileEntry, LotusLib::PackagesRead
 }
 
 void
+PreviewAudio::playPause()
+{
+    if (m_audioPlaybackWidget.isPlaying())
+    {
+        m_pauseButton->click();
+    }
+    else
+    {
+        m_playButton->click();
+    }
+}
+
+bool
+PreviewAudio::isVisible()
+{
+    return m_groupBox && m_groupBox->isVisible();
+}
+
+void
 PreviewAudio::createUi(QWidget* parentWidget)
 {
     m_rootLayout = new QVBoxLayout();

--- a/src/ui/preview/PreviewManager.cpp
+++ b/src/ui/preview/PreviewManager.cpp
@@ -60,6 +60,16 @@ PreviewManager::clearPreview()
     PreviewMessage::getInstance()->hide();
 }
 
+void
+PreviewManager::playPauseAudio()
+{
+    PreviewAudio* audioPreview = PreviewAudio::getInstance();
+    if (audioPreview->isVisible())
+    {
+        audioPreview->playPause();
+    }
+}
+
 Preview*
 PreviewManager::getPreview(LotusLib::FileEntry& fileEntry)
 {

--- a/ui/Exporter.ui
+++ b/ui/Exporter.ui
@@ -33,7 +33,7 @@
 	  <item>
            <widget class="QLineEdit" name="searchLineEdit">
             <property name="placeholderText">
-             <string>Search...</string>
+             <string>Regex Search...</string>
               </property>
                <property name="clearButtonEnabled">
                 <bool>true</bool>


### PR DESCRIPTION
***Shortcuts:***

**Global**
Quit - Ctrl+Q

**Start Window**
Load Exporter - something+Enter
Open Settings - Ctrl+.

**Exporter Window**
Search - Ctrl+F and /
Focus Tree - Ctrl+1
Focus Preview - Ctrl+2
Focus Metadata - Ctrl+3
Focus Format - Ctrl+4
Cycle through Focus - Alt+L,R
Extract Selected - Space\Enter

**Audio Preview**
Play/Pause - Shift+Space

***Regex search:***
Changed name from "Search..." to "Regex Search..."
Actually added regex search if the string is valid
<img width="738" height="356" alt="image" src="https://github.com/user-attachments/assets/7e2d4664-b834-43cd-b244-da1ecd0988be" />

Fixed crash in metadata/format tabs when you open them first without selecting anything
